### PR TITLE
Rework `monoize` to prevent bottlenecking and deadlocks in cIR

### DIFF
--- a/libcomune/core/traits.co
+++ b/libcomune/core/traits.co
@@ -5,11 +5,6 @@
 @lang(Copy)
 trait Copy {}
 
-@lang(Clone)
-trait Clone {
-	Self clone(&self);
-}
-
 @lang(Sized)
 trait Sized {}
 

--- a/libcomune/std/vector.co
+++ b/libcomune/std/vector.co
@@ -49,21 +49,6 @@ struct Vector<type T> {
 	}
 }
 
-using Test = Vector<int>;
-
-void foo() {
-	usize size = size_of<Test>();
-	Test mut* mut b = malloc(size) as Test mut*;
-	
-	unsafe {
-		new (*b) Vector<int> {
-			data: malloc(0) as int mut*,
-			len: 0,
-			capacity: 0
-		}
-	};
-}
-
 impl<type T> Vector<T> {
 
 	void push(mut& self, T elem) {

--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -437,10 +437,10 @@ pub enum XtorKind {
 	Constructor { args: Vec<Expr>, resolved: FnRef },
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum FnRef {
 	None,
-	Direct(Arc<RwLock<FnPrototype>>),
+	Direct(Arc<FnPrototype>),
 	Indirect(Box<Expr>),
 }
 
@@ -513,17 +513,6 @@ impl PartialEq for Atom {
 					false
 				}
 			}
-		}
-	}
-}
-
-impl PartialEq for FnRef {
-	fn eq(&self, other: &Self) -> bool {
-		match (self, other) {
-			(FnRef::Direct(l), FnRef::Direct(r)) => &*l.read().unwrap() == &*r.read().unwrap(),
-			(FnRef::Indirect(l0), FnRef::Indirect(r0)) => l0 == r0,
-			(FnRef::None, FnRef::None) => true,
-			_ => false,
 		}
 	}
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -121,9 +121,7 @@ impl<'ctx> FnScope<'ctx> {
 			// Look for it in the namespace tree
 			self.context.with_item(id, &self.scope, |item, id| {
 				if let ModuleItemInterface::Functions(fns) = item {
-					if fns.len() == 1 {
-						let func = &*fns[0].read().unwrap();
-
+					if let [func] = fns.read().unwrap().as_slice() {
 						result = Some((
 							id.clone(),
 							Type::Function(

--- a/src/ast/module.rs
+++ b/src/ast/module.rs
@@ -72,7 +72,7 @@ pub struct ModuleImpl {
 pub enum ModuleItemInterface {
 	Type(Arc<RwLock<TypeDef>>),
 	Trait(Arc<RwLock<TraitInterface>>),
-	Functions(Vec<Arc<RwLock<FnPrototype>>>),
+	Functions(Arc<RwLock<Vec<Arc<FnPrototype>>>>),
 	Variable(Type),
 	Alias(Identifier),
 	TypeAlias(Arc<RwLock<Type>>),
@@ -80,7 +80,7 @@ pub enum ModuleItemInterface {
 
 #[derive(Clone, Debug)]
 pub enum ModuleItemImpl {
-	Function(Arc<RwLock<FnPrototype>>, ModuleASTElem),
+	Function(Arc<FnPrototype>, ModuleASTElem),
 	Variable(ModuleASTElem),
 }
 

--- a/src/ast/module.rs
+++ b/src/ast/module.rs
@@ -80,7 +80,9 @@ pub enum ModuleItemInterface {
 
 impl ModuleImpl {
 	pub fn new() -> Self {
-		ModuleImpl { fn_impls: HashMap::new() }
+		ModuleImpl {
+			fn_impls: HashMap::new(),
+		}
 	}
 }
 

--- a/src/ast/module.rs
+++ b/src/ast/module.rs
@@ -91,10 +91,7 @@ impl ModuleInterface {
 		ModuleInterface {
 			path,
 			children: HashMap::new(),
-			import_names: HashSet::from([
-				ModuleImportKind::Language("core".into()),
-				ModuleImportKind::Language("std".into()),
-			]),
+			import_names: HashSet::new(),
 			imported: HashMap::new(),
 			impl_solver: ImplSolver::new(),
 			is_typed: false,

--- a/src/ast/module.rs
+++ b/src/ast/module.rs
@@ -78,12 +78,6 @@ pub enum ModuleItemInterface {
 	TypeAlias(Arc<RwLock<Type>>),
 }
 
-#[derive(Clone, Debug)]
-pub enum ModuleItemImpl {
-	Function(Arc<FnPrototype>, ModuleASTElem),
-	Variable(ModuleASTElem),
-}
-
 impl ModuleImpl {
 	pub fn new() -> Self {
 		ModuleImpl { fn_impls: vec![] }

--- a/src/ast/module.rs
+++ b/src/ast/module.rs
@@ -64,7 +64,7 @@ pub struct ModuleInterface {
 // i do not want to start doing newtype bullshit right now
 #[derive(Default, Debug)]
 pub struct ModuleImpl {
-	pub fn_impls: Vec<(Arc<RwLock<FnPrototype>>, ModuleASTElem)>,
+	pub fn_impls: Vec<(Arc<FnPrototype>, ModuleASTElem)>,
 }
 
 // I HATE RWLOCKS I HATE RWLOCKS I HATE RWLOCKS I HATE RWLOCKS I

--- a/src/ast/module.rs
+++ b/src/ast/module.rs
@@ -64,7 +64,7 @@ pub struct ModuleInterface {
 // i do not want to start doing newtype bullshit right now
 #[derive(Default, Debug)]
 pub struct ModuleImpl {
-	pub fn_impls: Vec<(Arc<FnPrototype>, ModuleASTElem)>,
+	pub fn_impls: HashMap<Arc<FnPrototype>, ModuleASTElem>,
 }
 
 // I HATE RWLOCKS I HATE RWLOCKS I HATE RWLOCKS I HATE RWLOCKS I
@@ -80,7 +80,7 @@ pub enum ModuleItemInterface {
 
 impl ModuleImpl {
 	pub fn new() -> Self {
-		ModuleImpl { fn_impls: vec![] }
+		ModuleImpl { fn_impls: HashMap::new() }
 	}
 }
 

--- a/src/ast/semantic/expr.rs
+++ b/src/ast/semantic/expr.rs
@@ -542,13 +542,7 @@ impl Atom {
 						let mut candidates: Vec<_> = def
 							.init
 							.iter()
-							.filter(|init| {
-								func::is_candidate_viable(
-									args,
-									&generic_args,
-									init,
-								)
-							})
+							.filter(|init| func::is_candidate_viable(args, &generic_args, init))
 							.cloned()
 							.collect();
 

--- a/src/ast/semantic/expr.rs
+++ b/src/ast/semantic/expr.rs
@@ -546,7 +546,7 @@ impl Atom {
 								func::is_candidate_viable(
 									args,
 									&generic_args,
-									&*init.read().unwrap(),
+									init,
 								)
 							})
 							.cloned()

--- a/src/ast/semantic/func.rs
+++ b/src/ast/semantic/func.rs
@@ -1,7 +1,4 @@
-use std::{
-	cmp::Ordering,
-	sync::Arc,
-};
+use std::{cmp::Ordering, sync::Arc};
 
 use crate::{
 	ast::{
@@ -305,17 +302,10 @@ pub fn try_select_candidate(
 		// More than one viable candidate
 		_ => {
 			// Sort candidates by cost
-			candidates.sort_unstable_by(|l, r| {
-				candidate_compare(args, l, r, scope)
-			});
+			candidates.sort_unstable_by(|l, r| candidate_compare(args, l, r, scope));
 
 			// Compare the top two candidates
-			match candidate_compare(
-				args,
-				&candidates[0],
-				&candidates[1],
-				scope,
-			) {
+			match candidate_compare(args, &candidates[0], &candidates[1], scope) {
 				Ordering::Less => Ok(candidates[0].clone()),
 
 				Ordering::Equal => Err(ComuneError::new(ComuneErrCode::AmbiguousCall, span)), // Ambiguous call

--- a/src/ast/semantic/func.rs
+++ b/src/ast/semantic/func.rs
@@ -1,6 +1,6 @@
 use std::{
 	cmp::Ordering,
-	sync::{Arc, RwLock},
+	sync::Arc,
 };
 
 use crate::{

--- a/src/ast/semantic/func.rs
+++ b/src/ast/semantic/func.rs
@@ -225,15 +225,11 @@ pub fn resolve_method_call(
 
 	args.insert(0, lhs.clone());
 
-	type_args.insert(0, receiver.clone());
-
 	if let Type::TypeRef { args, .. } = receiver {
-		type_args.reserve(args.len());
-
-		for (i, arg) in args.iter().enumerate() {
-			type_args.insert(i + 1, arg.clone());
-		}
+		type_args.append(&mut args.clone());
 	};
+
+	type_args.push(receiver.clone());
 
 	for arg in args.iter_mut() {
 		arg.validate(scope)?;

--- a/src/ast/semantic/func.rs
+++ b/src/ast/semantic/func.rs
@@ -289,7 +289,7 @@ pub fn try_select_candidate(
 	name: &Identifier,
 	args: &[Expr],
 	generic_args: &Vec<Type>,
-	candidates: &mut [Arc<RwLock<FnPrototype>>],
+	candidates: &mut [Arc<FnPrototype>],
 	span: SrcSpan,
 	scope: &FnScope,
 ) -> ComuneResult<Arc<RwLock<FnPrototype>>> {

--- a/src/ast/semantic/mod.rs
+++ b/src/ast/semantic/mod.rs
@@ -23,10 +23,10 @@ pub fn validate_module_impl(
 	module_impl: &mut ModuleImpl,
 ) -> ComuneResult<()> {
 	for (proto, ast) in &mut module_impl.fn_impls {
-		let mut scope = proto.read().unwrap().path.clone();
+		let mut scope = proto.path.clone();
 		scope.path.pop();
 
-		validate_function_body(scope.clone(), &*proto.read().unwrap(), ast, interface)?
+		validate_function_body(scope.clone(), &*proto, ast, interface)?
 	}
 
 	Ok(())

--- a/src/ast/semantic/mod.rs
+++ b/src/ast/semantic/mod.rs
@@ -34,7 +34,7 @@ pub fn validate_module_impl(
 
 pub fn validate_interface(_state: &Arc<CompilerState>, parser: &mut Parser) -> ComuneResult<()> {
 	// At this point, all imports have been resolved, so validate namespace-level types
-	ty::resolve_interface_types(&mut parser.interface)?;
+	ty::resolve_interface_types(parser)?;
 
 	// Check for cyclical dependencies without indirection
 	// TODO: Nice error reporting for this
@@ -63,8 +63,6 @@ fn validate_attributes(interface: &mut ModuleInterface) -> ComuneResult<()> {
 					let lang_trait = match &**name {
 						"Sized" => LangTrait::Sized,
 						"Copy" => LangTrait::Copy,
-						"Clone" => LangTrait::Clone,
-						"Drop" => LangTrait::Drop,
 						"Send" => LangTrait::Send,
 						"Sync" => LangTrait::Sync,
 						_ => panic!(),

--- a/src/ast/semantic/ty.rs
+++ b/src/ast/semantic/ty.rs
@@ -368,11 +368,12 @@ pub fn resolve_type_def(
 
 	// This part is ugly as hell. sorry
 
-	if let Some(drop) = &ty.drop {
-		resolve_function_prototype(&mut *drop.write().unwrap(), interface)?;
+	if let Some(mut drop) = &mut ty.drop {
+		let drop_ref = Arc::make_mut(&mut drop);
+
+		resolve_function_prototype(drop_ref, interface)?;
 
 		// Check whether the first parameter exists and is `mut& self`
-		let drop = drop.read().unwrap();
 
 		let Some((Type::TypeRef { def, .. }, _, props)) = drop.params.params.get(0) else {
 			return Err(ComuneError::new(

--- a/src/ast/semantic/ty.rs
+++ b/src/ast/semantic/ty.rs
@@ -73,7 +73,8 @@ pub fn resolve_interface_types(parser: &mut Parser) -> ComuneResult<()> {
 						// Update the module impl's version of the prototype
 						// because everything is terrible and i hate my past self
 						let fn_body = module_impl.fn_impls.remove(func_og).unwrap();
-						module_impl.fn_impls.insert(func_arc, fn_body);
+						module_impl.fn_impls.insert(func_arc.clone(), fn_body);
+						*func_og = func_arc;
 					}
 				}
 			}
@@ -232,7 +233,8 @@ pub fn resolve_interface_types(parser: &mut Parser) -> ComuneResult<()> {
 
 				// Update the module impl's version of the prototype
 				let fn_body = module_impl.fn_impls.remove(func_og).unwrap();
-				module_impl.fn_impls.insert(func_arc, fn_body);
+				module_impl.fn_impls.insert(func_arc.clone(), fn_body);
+				*func_og = func_arc;
 			}
 		}
 
@@ -481,7 +483,9 @@ pub fn resolve_function_prototype(
 
 	// Update the module impl's version of the prototype
 	let fn_body = module_impl.fn_impls.remove(func_og).unwrap();
-	module_impl.fn_impls.insert(func_arc, fn_body);
+	module_impl.fn_impls.insert(func_arc.clone(), fn_body);
+	
+	*func_og = func_arc;
 
 	Ok(())
 }

--- a/src/ast/semantic/ty.rs
+++ b/src/ast/semantic/ty.rs
@@ -484,7 +484,7 @@ pub fn resolve_function_prototype(
 	// Update the module impl's version of the prototype
 	let fn_body = module_impl.fn_impls.remove(func_og).unwrap();
 	module_impl.fn_impls.insert(func_arc.clone(), fn_body);
-	
+
 	*func_og = func_arc;
 
 	Ok(())

--- a/src/ast/traits.rs
+++ b/src/ast/traits.rs
@@ -39,7 +39,7 @@ pub struct TraitRef {
 
 #[derive(Debug)]
 pub struct TraitInterface {
-	pub items: HashMap<Name, Vec<Arc<RwLock<FnPrototype>>>>,
+	pub items: HashMap<Name, Vec<Arc<FnPrototype>>>,
 	pub types: HashMap<Name, GenericParam>, // Associated types
 	pub supers: Vec<Identifier>,
 	pub attributes: Vec<Attribute>,
@@ -48,7 +48,7 @@ pub struct TraitInterface {
 #[derive(Debug, Clone)]
 pub struct ImplBlockInterface {
 	pub implements: Option<ItemRef<TraitRef>>,
-	pub functions: HashMap<Name, Vec<Arc<RwLock<FnPrototype>>>>,
+	pub functions: HashMap<Name, Vec<Arc<FnPrototype>>>,
 	pub types: HashMap<Name, Type>,
 	pub scope: Arc<Identifier>, // The scope used for name resolution within the impl
 	pub canonical_root: Identifier, // The root of the canonical names used by items in this impl

--- a/src/ast/traits.rs
+++ b/src/ast/traits.rs
@@ -24,8 +24,6 @@ use lazy_static::lazy_static;
 pub enum LangTrait {
 	Sized,
 	Copy,
-	Clone,
-	Drop,
 	Send,
 	Sync,
 }

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -670,8 +670,8 @@ impl PartialEq for Type {
 				Arc::ptr_eq(&l0.upgrade().unwrap(), &r0.upgrade().unwrap()) && l1 == r1
 			}
 
-			(Self::Unresolved { .. }, _) | (_, Self::Unresolved { .. }) => {
-				panic!("cannot compare unresolved types!")
+			(Self::Unresolved { name: l0, scope: l1, type_args: l2, .. }, Self::Unresolved { name: r0, scope: r1, type_args: r2, .. }) => {
+				l0 == r0 && l1 == r1 && l2 == r2
 			}
 
 			(Self::Slice(l0), Self::Slice(r0)) => l0 == r0,

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -81,7 +81,7 @@ pub struct TypeDef {
 	pub params: Generics,
 	pub attributes: Vec<Attribute>,
 
-	pub init: Vec<Arc<FnPrototype>>, // Zero or more constructors
+	pub init: Vec<Arc<FnPrototype>>,    // Zero or more constructors
 	pub drop: Option<Arc<FnPrototype>>, // Zero or one destructor
 }
 

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -266,8 +266,6 @@ impl Basic {
 				IntSize::I32 => "i32",
 				IntSize::I16 => "i16",
 				IntSize::I8 => "i8",
-
-				_ => panic!(),
 			},
 
 			Basic::Integral {
@@ -279,8 +277,6 @@ impl Basic {
 				IntSize::I32 => "u32",
 				IntSize::I16 => "u16",
 				IntSize::I8 => "u8",
-
-				_ => panic!(),
 			},
 
 			Basic::Float {

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -81,8 +81,8 @@ pub struct TypeDef {
 	pub params: Generics,
 	pub attributes: Vec<Attribute>,
 
-	pub init: Vec<Arc<RwLock<FnPrototype>>>, // Zero or more constructors
-	pub drop: Option<Arc<RwLock<FnPrototype>>>, // Zero or one destructor
+	pub init: Vec<Arc<FnPrototype>>, // Zero or more constructors
+	pub drop: Option<Arc<FnPrototype>>, // Zero or one destructor
 }
 
 #[derive(Default, Debug, Clone, Copy)]

--- a/src/cir/analyze/lifeline.rs
+++ b/src/cir/analyze/lifeline.rs
@@ -1,6 +1,6 @@
 // lifeline - the comune liveness & borrow checker
 
-use std::{collections::HashMap, fmt::Display, sync::Arc};
+use std::{collections::HashMap, fmt::Display};
 
 use super::{
 	Analysis, AnalysisDomain, AnalysisResultHandler, Forward, JoinSemiLattice, ResultVisitor,

--- a/src/cir/analyze/lifeline.rs
+++ b/src/cir/analyze/lifeline.rs
@@ -373,17 +373,22 @@ impl AnalysisResultHandler<DefInitFlow> for VarInitCheck {
 					CIRStmt::Invoke { args, .. } | CIRStmt::Call { args, .. } => {
 						for (lval, _, use_props) in args {
 							let liveness = state.get_liveness(lval);
-							
+
 							if use_props.is_new {
 								match liveness {
-									None | Some(LivenessState::Uninit | LivenessState::Dropped | LivenessState::Moved) => {}
+									None
+									| Some(
+										LivenessState::Uninit
+										| LivenessState::Dropped
+										| LivenessState::Moved,
+									) => {}
 
 									_ => errors.push(ComuneError::new(
 										ComuneErrCode::InvalidNewReference {
 											variable: func.get_variable_name(lval.local),
 										},
 										lval.props.span,
-									))
+									)),
 								}
 							} else {
 								match liveness {
@@ -398,7 +403,6 @@ impl AnalysisResultHandler<DefInitFlow> for VarInitCheck {
 									)),
 								}
 							}
-							
 						}
 					}
 
@@ -590,7 +594,7 @@ impl<'func> DropElaborator<'func> {
 
 				if let Some(drop) = &def.drop {
 					if self.state.get_liveness(lval) == Some(LivenessState::Live) {
-						let drop = Arc::new(drop.read().unwrap().clone());
+						let drop = drop.clone();
 
 						self.write(CIRStmt::Call {
 							id: CIRCallId::Direct(drop, SrcSpan::new()),

--- a/src/cir/builder.rs
+++ b/src/cir/builder.rs
@@ -67,10 +67,9 @@ impl CIRModuleBuilder {
 
 			for (_, fns) in &im.functions {
 				for func in fns {
-					let proto = Arc::new(func.read().unwrap().clone());
-					let cir_fn = Self::generate_prototype(&proto);
+					let cir_fn = Self::generate_prototype(&func);
 
-					self.module.functions.insert(proto, cir_fn);
+					self.module.functions.insert(func.clone(), cir_fn);
 				}
 			}
 		}
@@ -84,11 +83,10 @@ impl CIRModuleBuilder {
 		for (name, item) in &module.children {
 			match item {
 				ModuleItemInterface::Functions(fns) => {
-					for func in fns {
-						let proto = Arc::new(func.read().unwrap().clone());
-						let cir_fn = Self::generate_prototype(&proto);
+					for func in &*fns.read().unwrap() {
+						let cir_fn = Self::generate_prototype(func);
 
-						self.module.functions.insert(proto, cir_fn);
+						self.module.functions.insert(func.clone(), cir_fn);
 					}
 				}
 
@@ -102,7 +100,7 @@ impl CIRModuleBuilder {
 					}
 
 					for init in &ty.read().unwrap().init {
-						let proto = Arc::new(init.read().unwrap().clone());
+						let proto = init.clone();
 						let cir_fn = Self::generate_prototype(&proto);
 
 						self.module.functions.insert(proto, cir_fn);
@@ -1285,8 +1283,6 @@ impl CIRModuleBuilder {
 	) -> Option<RValue> {
 		match resolved {
 			FnRef::Direct(resolved) => {
-				let resolved = resolved.read().unwrap();
-
 				let (ret_props, ret) = resolved.ret.clone();
 				let ret = ret.get_concrete_type(generic_args);
 

--- a/src/cir/monoize.rs
+++ b/src/cir/monoize.rs
@@ -227,7 +227,12 @@ impl MonomorphServer {
 		access: &mut ModuleAccess,
 	) {
 		if generic_args.is_empty() {
-			return;
+			if !access.fns_in.contains_key(id) {
+				let extern_fn = CIRModuleBuilder::generate_prototype(id);
+				access.fns_out.insert(id.clone(), extern_fn);
+			}
+
+			return
 		}
 
 		let (func, body) = self.register_fn_job(id, generic_args, access);
@@ -471,8 +476,6 @@ impl MonomorphServer {
 		
 		let mut func_new = func.as_ref().clone();
 		
-		println!("registering job {func_new} with {args:?}");
-
 		self.monoize_prototype(&mut func_new, args, access);
 
 		let func_new = Arc::new(func_new);

--- a/src/cir/monoize.rs
+++ b/src/cir/monoize.rs
@@ -397,10 +397,11 @@ impl MonomorphServer {
 					self.register_fn_template(&drop_fn, drop_body);
 				}
 
-				let (drop_fn, drop_body) = self.register_fn_job(drop_fn.as_ref().clone(), &generic_args);
-				
+				let (drop_fn, drop_body) =
+					self.register_fn_job(drop_fn.as_ref().clone(), &generic_args);
+
 				fns_out.insert(drop_fn.clone(), drop_body);
-				
+
 				// this is really ugly. we have to go back and forth between
 				// Arc<T> and Arc<RwLock<T>> a lot because of annoying reasons
 				//
@@ -418,20 +419,27 @@ impl MonomorphServer {
 			Arc::downgrade(&instance_arc)
 		}
 	}
-	
+
 	// Register a function template if it hasn't been registered already
 	// which it.. technically never should? hm. i dunno let's just be safe
 	fn register_fn_template(&self, func: &FnPrototype, body: &CIRFunction) {
 		if self.fn_templates.read().unwrap().contains_key(func) {
-			return
+			return;
 		}
 
-		self.fn_templates.write().unwrap().insert(Arc::new(func.clone()), body.clone());
+		self.fn_templates
+			.write()
+			.unwrap()
+			.insert(Arc::new(func.clone()), body.clone());
 	}
 
 	// Request a function instance, returning an `extern` fn
 	// and adding it to the MonomorphServer's job list
-	fn register_fn_job(&self, mut func: FnPrototype, args: &GenericArgs) -> (Arc<FnPrototype>, CIRFunction) {		
+	fn register_fn_job(
+		&self,
+		mut func: FnPrototype,
+		args: &GenericArgs,
+	) -> (Arc<FnPrototype>, CIRFunction) {
 		for (i, arg) in args.iter().enumerate() {
 			func.generics[i].2 = Some(arg.clone())
 		}

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -175,9 +175,7 @@ pub fn generate_cpp_header(
 	for (name, item) in &input.children {
 		match item {
 			ModuleItemInterface::Functions(fns) => {
-				for func in fns {
-					let func = &*func.read().unwrap();
-
+				for func in &*fns.read().unwrap() {
 					if get_attribute(&func.attributes, "no_mangle").is_some() {
 						write!(result, "extern \"C\" ")?;
 					}

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,5 +1,5 @@
 use std::{
-	collections::HashMap,
+	collections::{HashMap, HashSet},
 	ffi::OsString,
 	fs,
 	path::{Path, PathBuf},
@@ -362,14 +362,13 @@ pub fn get_module_out_path(state: &CompilerState, module: &Identifier) -> PathBu
 }
 
 pub fn parse_interface(
-	state: &Arc<CompilerState>,
+	_state: &Arc<CompilerState>,
 	path: &Path,
 	error_sender: Sender<CMNMessageLog>,
 ) -> Result<Parser, ComuneError> {
 	// First phase of module compilation: create Lexer and Parser, and parse the module at the namespace level
 
 	let mut mod_state = Parser::new(match Lexer::new(path, error_sender) {
-		// TODO: Take module name instead of filename
 		Ok(f) => f,
 		Err(e) => {
 			println!(
@@ -385,9 +384,11 @@ pub fn parse_interface(
 		}
 	});
 
-	if state.verbose_output {
-		println!("\ncollecting symbols...");
-	}
+	// TODO: HEY ASH TOMORROW MORNING MAKE IT SO CORE DOESN'T IMPORT STD
+	mod_state.interface.import_names = HashSet::from([
+		ModuleImportKind::Language("core".into()),
+		ModuleImportKind::Language("std".into()),
+	]);
 
 	// Parse namespace level
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -684,7 +684,7 @@ pub fn generate_llvm_ir<'ctx>(
 			"an internal compiler error occurred:".red().bold(),
 			lexer::get_escaped(e.to_str().unwrap())
 		);
-		
+
 		let boguspath = out_path.with_extension("llbogus");
 
 		// Output bogus LLVM here, for debugging purposes

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -12,7 +12,8 @@ use inkwell::{context::Context, passes::PassManager, targets::FileType};
 use crate::{
 	ast::{
 		self,
-		module::{Identifier, ModuleImport, ModuleImportKind, ModuleInterface, Name}, semantic::validate_module_impl,
+		module::{Identifier, ModuleImport, ModuleImportKind, ModuleInterface, Name},
+		semantic::validate_module_impl,
 	},
 	cir::{
 		analyze::{
@@ -529,7 +530,6 @@ pub fn generate_code<'ctx>(
 	src_path: &Path,
 	input_module: &Identifier,
 ) -> Result<LLVMBackend<'ctx>, ComuneError> {
-
 	// Generate AST
 	if let Err(e) = parser.generate_ast() {
 		parser
@@ -537,7 +537,7 @@ pub fn generate_code<'ctx>(
 			.borrow()
 			.log_msg(ComuneMessage::Error(e.clone()));
 
-		return Err(e)
+		return Err(e);
 	}
 
 	// Finalize impl solver, so we can query it
@@ -550,9 +550,9 @@ pub fn generate_code<'ctx>(
 			.borrow()
 			.log_msg(ComuneMessage::Error(e.clone()));
 
-		return Err(e)
+		return Err(e);
 	}
-	
+
 	// Generate cIR
 	let module_name = input_module.to_string();
 	let mut cir_module = CIRModuleBuilder::from_ast(parser).module;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -337,7 +337,10 @@ impl Display for ComuneErrCode {
 			}
 
 			ComuneErrCode::InvalidNewReference { variable } => {
-				write!(f, "variable {variable} must be uninitialized to pass as new&")
+				write!(
+					f,
+					"variable {variable} must be uninitialized to pass as new&"
+				)
 			}
 
 			ComuneErrCode::ImmutVarMutation { variable } => {

--- a/src/llvm.rs
+++ b/src/llvm.rs
@@ -1023,7 +1023,10 @@ impl<'ctx> LLVMBackend<'ctx> {
 				}
 			}
 
-			Type::TypeRef { .. } => self.type_map[&ty.get_ir_typename()],
+			Type::TypeRef { .. } => {
+				let ir_typename = ty.get_ir_typename();
+				self.type_map[&ir_typename]
+			}
 
 			Type::Tuple(kind, types) => {
 				let types_mapped: Vec<_> = types

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,10 +119,11 @@ fn main() -> color_eyre::eyre::Result<()> {
 		}
 	});
 
-	rayon::in_place_scope(|s| {
-		driver::generate_monomorph_module(
-			compiler_state.clone()
-		);
+	rayon::in_place_scope(|_| {
+		match driver::generate_monomorph_module(compiler_state.clone()) {
+			Ok(()) => {},
+			Err(_) => { errors::ERROR_COUNT.fetch_add(1, Ordering::Relaxed); },
+		};
 	});
 
 	if errors::ERROR_COUNT.load(Ordering::Acquire) > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,12 @@ fn main() -> color_eyre::eyre::Result<()> {
 		}
 	});
 
+	rayon::in_place_scope(|s| {
+		driver::generate_monomorph_module(
+			compiler_state.clone()
+		);
+	});
+
 	if errors::ERROR_COUNT.load(Ordering::Acquire) > 0 {
 		error_sender
 			.send(errors::CMNMessageLog::Raw(format!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -279,13 +279,13 @@ impl<'ctx> Parser {
 								let mut path = Identifier::from_parent(&scope, k.into());
 								path.qualifier.0 = Some(Box::new(self_ty.clone()));
 
-								let func = Arc::new(RwLock::new(FnPrototype {
+								let func = Arc::new(FnPrototype {
 									path,
 									params,
 									generics,
 									ret: (BindingProps::default(), Type::Basic(Basic::Void)),
 									attributes: vec![],
-								}));
+								});
 
 								// Skip c'tor/d'tor body
 								let ast = self.get_current_token_index();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,7 +11,7 @@ use crate::ast::controlflow::ControlFlow;
 use crate::ast::expression::{Atom, Expr, FnRef, NodeData, Operator, XtorKind};
 use crate::ast::module::{
 	Identifier, ItemRef, ModuleASTElem, ModuleImpl, ModuleImportKind, ModuleInterface,
-	ModuleItemImpl, ModuleItemInterface, Name,
+	ModuleItemInterface, Name,
 };
 use crate::ast::statement::Stmt;
 use crate::ast::traits::{ImplBlockInterface, TraitInterface, TraitRef};
@@ -336,7 +336,7 @@ impl<'ctx> Parser {
 						return self.err(ComuneErrCode::UnexpectedToken);
 					};
 
-					let mut this_trait = TraitInterface {
+					let this_trait = TraitInterface {
 						items: HashMap::new(),
 						types: HashMap::new(),
 						supers: vec![],
@@ -377,7 +377,7 @@ impl<'ctx> Parser {
 								}
 							}
 	
-							(DeclParseResult::Variable(name, ty), ast) => todo!()
+							(DeclParseResult::Variable(..), _) => todo!()
 						}
 
 						next = self.get_current()?;
@@ -607,7 +607,7 @@ impl<'ctx> Parser {
 							}
 						}
 
-						(DeclParseResult::Variable(name, ty), ast) => todo!()
+						(DeclParseResult::Variable(..), _) => todo!()
 					}
 				}
 			}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -115,11 +115,8 @@ impl<'ctx> Parser {
 			if let ModuleASTElem::Unparsed(idx) = ast {
 				self.lexer.borrow_mut().seek_token_idx(*idx);
 
-				let scope = FnScope::new(
-					&self.interface,
-					proto.path.clone(),
-					proto.ret.clone(),
-				).with_params(proto.generics.clone());
+				let scope = FnScope::new(&self.interface, proto.path.clone(), proto.ret.clone())
+					.with_params(proto.generics.clone());
 
 				fn_impls.insert(
 					proto.clone(),
@@ -354,19 +351,21 @@ impl<'ctx> Parser {
 					while !token_compare(&next, "}") {
 						let func_attributes = self.parse_attributes()?;
 
-						match self.parse_namespace_declaration(func_attributes, Some(&Type::TypeParam(0)))? {
-
+						match self.parse_namespace_declaration(
+							func_attributes,
+							Some(&Type::TypeParam(0)),
+						)? {
 							(DeclParseResult::Function(name, proto), ast) => {
 								self.module_impl.fn_impls.insert(proto.clone(), ast);
-	
+
 								if let Some(existing) = this_trait.items.get_mut(&name) {
 									existing.push(proto);
 								} else {
 									this_trait.items.insert(name, vec![proto]);
 								}
 							}
-	
-							(DeclParseResult::Variable(..), _) => todo!()
+
+							(DeclParseResult::Variable(..), _) => todo!(),
 						}
 
 						next = self.get_current()?;
@@ -450,7 +449,7 @@ impl<'ctx> Parser {
 						});
 
 						if let Some(existing) = functions.get_mut(&fn_name) {
-							existing.push(proto.clone());		
+							existing.push(proto.clone());
 						} else {
 							functions.insert(fn_name.clone(), vec![proto.clone()]);
 						}
@@ -577,12 +576,10 @@ impl<'ctx> Parser {
 					// Parse declaration/definition
 
 					match self.parse_namespace_declaration(current_attributes, None)? {
-
 						(DeclParseResult::Function(name, proto), ast) => {
-
 							let id = Identifier::from_parent(scope, name);
 							let module_interface = &mut self.interface;
-							
+
 							self.module_impl.fn_impls.insert(proto.clone(), ast);
 
 							if let Some(ModuleItemInterface::Functions(existing)) =
@@ -591,15 +588,15 @@ impl<'ctx> Parser {
 								existing.write().unwrap().push(proto);
 							} else {
 								module_interface.children.insert(
-									id, 
-									ModuleItemInterface::Functions(
-										Arc::new(RwLock::new(vec![proto]))
-									)
+									id,
+									ModuleItemInterface::Functions(Arc::new(RwLock::new(vec![
+										proto,
+									]))),
 								);
 							}
 						}
 
-						(DeclParseResult::Variable(..), _) => todo!()
+						(DeclParseResult::Variable(..), _) => todo!(),
 					}
 				}
 			}

--- a/test/src/main.co
+++ b/test/src/main.co
@@ -53,8 +53,8 @@ impl Hello for Test {
 
 void impl_test() {
 	Test test = new Test { a: 413, b: 612, };
-	//test.hello();
-	//printf(c"The sum of a and b is %i!\n", test.sum());
+	test.hello();
+	printf(c"The sum of a and b is %i!\n", test.sum());
 }
 
 void ref_test(i32 mut& test) {
@@ -244,7 +244,7 @@ int main() {
 	ref_test(int_ref_test);
 	printf(c"int_ref_test: %i\n", int_ref_test);
 
-	//printf(c"Temporary->lvalue promotion: %i\n", new Test { a: 23, b: 35 }.sum());
+	printf(c"Temporary->lvalue promotion: %i\n", new Test { a: 23, b: 35 }.sum());
 
 	printf(c"bit_cast<f32, u32>: %i\n", bit_cast<f32, u32>(10.0f32));
 	return 0;

--- a/test/src/main.co
+++ b/test/src/main.co
@@ -53,8 +53,8 @@ impl Hello for Test {
 
 void impl_test() {
 	Test test = new Test { a: 413, b: 612, };
-	test.hello();
-	printf(c"The sum of a and b is %i!\n", test.sum());
+	//test.hello();
+	//printf(c"The sum of a and b is %i!\n", test.sum());
 }
 
 void ref_test(i32 mut& test) {
@@ -244,7 +244,7 @@ int main() {
 	ref_test(int_ref_test);
 	printf(c"int_ref_test: %i\n", int_ref_test);
 
-	printf(c"Temporary->lvalue promotion: %i\n", new Test { a: 23, b: 35 }.sum());
+	//printf(c"Temporary->lvalue promotion: %i\n", new Test { a: 23, b: 35 }.sum());
 
 	printf(c"bit_cast<f32, u32>: %i\n", bit_cast<f32, u32>(10.0f32));
 	return 0;


### PR DESCRIPTION
This PR changes the way monomorphization works, to solve various deadlocks and bottlenecks in the cIR phase of the compiler.

Previously, instantiating a generic function would involve blocking the thread until the function template became available from its source module. This was a temporary solution, and was prone to deadlocking in error conditions, as well as being flat-out wrong in a single-threaded context.

This PR moves monomorphization work to a discrete step in the compilation process, rendering it more robust and work-efficient, while having no notable impact on performance and opening the process up to future optimizations.